### PR TITLE
[feat] Add slider tooltip slot for custom content.

### DIFF
--- a/src/lib/Slider/Slider.svelte
+++ b/src/lib/Slider/Slider.svelte
@@ -194,8 +194,9 @@ A slider is a control that lets the user select from a range of values by moving
 	>
 		{#if tooltip && !disabled}
 			<TooltipSurface class="slider-tooltip">
-				{prefix}{value}{suffix}
-				<slot name="tooltip" />
+                <slot name="tooltip" {prefix} {suffix} {value}>
+                    {prefix}{value}{suffix}
+                </slot>
 			</TooltipSurface>
 		{/if}
 	</div>

--- a/src/routes/docs/components/slider.md
+++ b/src/routes/docs/components/slider.md
@@ -92,6 +92,21 @@ Tooltip text can also be customized through the `prefix` and `suffix` properties
 <Slider suffix=" meters" />
 ```
 
+If you require further tooltip configuration, the tooltip's content can also be entirely overrided with your own using the `tooltip` slot.
+
+The `tooltip` slot has three slot props: `value`, `prefix` and `suffix` which grant you access to the current value and the prefix/suffix strings respectively.
+
+```html
+<Slider>
+    <svelte:fragment slot="tooltip" let:value let:prefix let:suffix>
+        {prefix}{value}{suffix}
+        <h1>
+            Custom HTML content!
+        </h1>
+    </svelte:fragment>
+</Slider>
+```
+
 ### Direction and Orientation
 
 Sliders can be displayed in either a horizontal (left and right) or vertical orientation (up and down). By default, sliders are displayed in a horizontal orientation. You can change this by setting the `orientation` property to `"vertical"`.

--- a/src/site/lib/APIDocs/APIDocs.svelte
+++ b/src/site/lib/APIDocs/APIDocs.svelte
@@ -93,7 +93,7 @@ and
 						{/if}
 					</td>
 					<td>
-						{#if Object.keys(JSON.parse(slot_props)).length > 0}
+						{#if slot_props}
 							<code>{slot_props}</code>
 						{:else}
 							None
@@ -115,7 +115,6 @@ and
 {/if}
 
 <h3>Events</h3>
-
 {#if manualForward}
 	<h4>Forwarded Events</h4>
 	{#if forwardedEvents.length > 0}


### PR DESCRIPTION
Allows the developer to override inner tooltip text through slots. Exposes `prefix`, `suffix` and `value` as slot props.