### PR TITLE
Fix non-logical text alignment

### DIFF
--- a/src/lib/ComboBox/ComboBox.scss
+++ b/src/lib/ComboBox/ComboBox.scss
@@ -89,7 +89,7 @@
 
 	&-label {
 		flex: 1 1 auto;
-		text-align: left;
+		text-align: start;
 		min-block-size: 20px;
 
 		&.placeholder {

--- a/src/lib/Expander/Expander.scss
+++ b/src/lib/Expander/Expander.scss
@@ -63,7 +63,7 @@
 	&-header {
 		@include flex($align: center);
 		@include typography-body;
-		text-align: left;
+		text-align: start;
 		outline: none;
 		box-sizing: border-box;
 		padding-inline-start: 16px;

--- a/src/lib/MenuFlyout/MenuFlyoutItem.scss
+++ b/src/lib/MenuFlyout/MenuFlyoutItem.scss
@@ -130,7 +130,7 @@
 
 	> :global(.menu-flyout-item-hint) {
 		flex: 1 1 auto;
-		text-align: right;
+		text-align: end;
 		padding-left: 24px;
 		overflow: hidden;
 		text-overflow: ellipsis;


### PR DESCRIPTION
Small i18n fix: changes every instance of `text-align: left`/`right` to `start`/`end` to be compatible with RtL languages.