### PR TITLE
Fix homepage icon displacement

### DIFF
--- a/src/site/lib/HeroCard/HeroCard.scss
+++ b/src/site/lib/HeroCard/HeroCard.scss
@@ -4,6 +4,7 @@
 	@include typography-body;
 	@include flex($direction: column);
 	box-sizing: border-box;
+	position: relative;
 	padding: 12px;
 	backdrop-filter: blur(60px) saturate(125%);
 	border-radius: var(--overlay-corner-radius);


### PR DESCRIPTION
Before (just hovering my cursor in place):
https://user-images.githubusercontent.com/22732095/152656536-c3c2f636-f53a-4029-8ab5-bbc979c52a73.mp4

After:
<img width="949" alt="Better aligned icons" src="https://user-images.githubusercontent.com/22732095/152656554-88ce5fa3-acd6-4ae4-b417-13b979ea6edd.png">

