### PR TITLE
Improved AutoSuggessBox & Prevent Close of Flyout

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"@fluentui/svg-icons": "^1.1.166",
 		"@sveltejs/adapter-vercel": "next",
 		"@sveltejs/kit": "^1.0.0-next.310",
-		"@sveltejs/svelte-repl": "^0.2.2",
+		"@sveltejs/svelte-repl": "^0.4.1",
 		"@types/prismjs": "^1.26.0",
 		"autoprefixer": "^10.4.4",
 		"cssnano": "^5.1.7",

--- a/src/app.html
+++ b/src/app.html
@@ -4,9 +4,9 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="/logo.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		%svelte.head%
+		%sveltekit.head%
 	</head>
 	<body>
-		<div id="svelte">%svelte.body%</div>
+		<div id="svelte">%sveltekit.body%</div>
 	</body>
 </html>

--- a/src/lib/Flyout/FlyoutWrapper.svelte
+++ b/src/lib/Flyout/FlyoutWrapper.svelte
@@ -58,12 +58,6 @@
 		if (closable) open = false;
 	}
 
-	function handleKeyDown(event: KeyboardEvent) {
-		if (event.key === " " || event.key === "Enter") {
-			event.preventDefault();
-			open = !open;
-		}
-	}
 </script>
 
 <!--
@@ -88,7 +82,6 @@ Flyouts represent a control that displays lightweight UI that is either informat
 	aria-haspopup={open}
 	aria-controls={menuId}
 	on:click={() => (open = !open)}
-	on:keydown={handleKeyDown}
 	bind:this={wrapperElement}
 >
 	<slot />

--- a/src/routes/test/index.svelte
+++ b/src/routes/test/index.svelte
@@ -215,7 +215,31 @@
 	>
 		<Flyout placement="top" bind:open={flyoutTopOpen}>
 			<Button variant="accent">Top Flyout</Button>
-			<svelte:fragment slot="flyout">Flyout Content</svelte:fragment>
+			<svelte:fragment slot="flyout"
+				><AutoSuggestBox
+					on:select={(e) => console.log("Selected!", e)}
+					on:input={(e) => console.log("Input!", e)}
+					on:search={(e) => console.log("Search!", e)}
+					on:cleear={(e) => console.log("Clear!", e)}
+					on:change={(e) => console.log("Change!", e)}
+					placeholder="Search fruits"
+					items={[
+						"Apple",
+						"Orange",
+						"Grape",
+						"Mango",
+						"Pear",
+						"Banana",
+						"Strawberry",
+						"Watermelon",
+						"Cherry"
+					]}
+				/></svelte:fragment
+			>
+		</Flyout>
+		<Flyout placement="top" bind:open={flyoutTopOpen}>
+			<Button variant="accent">Top Flyout</Button>
+			<svelte:fragment slot="flyout" />
 		</Flyout>
 		<Flyout placement="bottom" bind:open={flyoutBottomOpen}>
 			<Button variant="accent">Bottom Flyout</Button>


### PR DESCRIPTION
### Considering #47 


### 1. AutoSuggessBox.

- [x] Do not auto-select the first element of the array.

Now if the user select the first element, all the events will return the value of `Array[0]`

-----
- [x] Dispatch 'Select' Event does not make sure to update the current value of the AutoSuggestBox

Fixed and now we will get the updated value.

-----
- [x] Adding the 'on:select' event on component allows better mobile performance

Added on select event, 

----

- [x] Don't auto select any element for just use the arrow key moving

Selections will be triggered with `Enter` key when focused on an item


### 2. Flyout

- [x] Don't auto close the flyout when push `Enter` key
