### PR TITLE
remove unused css selector

### DIFF
--- a/src/lib/Expander/Expander.scss
+++ b/src/lib/Expander/Expander.scss
@@ -55,9 +55,6 @@
 			}
 		}
 	}
-	> h3 {
-		display: contents;
-	}
 	&-icon {
 		flex: 0 0 auto;
 		color: var(--text-primary);


### PR DESCRIPTION
This PR removes the unused css error that is caused by the 58th line of [Expander/Expander.scss](https://github.com/Tropix126/fluent-svelte/pull/52/commits/42c2edc5a0351b3be4a736fb96617a5862afe7e7#diff-4c2f0d8c9d3e3d7c61c3635f84378bccaa7d088fcf67557e10ac797285e90ee6)

![image](https://user-images.githubusercontent.com/42965116/174492025-dc4cea87-87eb-49df-9246-8111834e1d17.png)

SvelteKit v1.0.0-next.350
