### PR TITLE
fixed low display-resolution hover animation

### DIFF
--- a/src/lib/RadioButton/RadioButton.scss
+++ b/src/lib/RadioButton/RadioButton.scss
@@ -66,8 +66,7 @@
 			visibility: visible;
 			transition: var(--control-normal-duration) var(--control-fast-out-slow-in-easing);
 			box-shadow: 0 0 0 1px var(--control-stroke-default);
-			inline-size: 12px;
-			block-size: 12px;
+			transform: scale(1.2);
 		}
 
 		&:hover {


### PR DESCRIPTION
On non iris displays, (most displays) a hover effect will cause the core dot to scale very in fluently. Using transition will scale the core in a fluent way.